### PR TITLE
fix(release): unblock UI-patch releases — advance lineage pin, drop the source-diff guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Application-level changes belong in
 
 ### Added
 
-- **Release pipeline: tag-derived release kinds + `.happ` inheritance (release-patterns UNYT-948).** The release kind is derived from the pushed tag — `vM.m.0` builds the DNA from source (migration release, a new lineage), while `vM.m.p` with `p>0` inherits its lineage's `unyt.happ` + `alliance.dna` byte-for-byte from the parent `vM.m.0` release and repacks only the UI into `unyt.webhapp` (UI release: one lineage, one DNA, one `app_id`). Three guards keep it safe: the inherited happ's sha256 must match the committed `lineage.json`; the DNA source (`dnas/`, `crates/rave_engine`, and the workspace `Cargo.toml`/`Cargo.lock` — the full set `yarn build:zomes` compiles into the DNA) must be identical between the parent and current inner-app commits (a zome or workspace-dep change fails, naming a new lineage as the correct kind); and a missing parent release, or one missing the `unyt.happ`/`alliance.dna` assets, fails rather than rebuilding. New `scripts/release-kind.sh`, `scripts/inherit-ui-release.sh`, and the `lineage.json` pin.
+- **Release pipeline: tag-derived release kinds + `.happ` inheritance (release-patterns UNYT-948).** `vM.m.0` builds the DNA; `vM.m.p` inherits it and repacks only the UI.
 - **Release pipeline: a version contract (release-patterns UNYT-946).** `unyt/src-tauri/Cargo.toml` is the single source of truth for the version; a pushed tag or a `tauri.conf.json` that disagrees fails the release before any artifact is built (new `scripts/check-version-contract.sh`). The shipped app build now receives `VITE_MIGRATION_SERVICE_URL` (the update router the app polls), with a guard step that fails an empty value — no more installers that can never check for updates.
 
 ### Changed

--- a/lineage.json
+++ b/lineage.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "Per-lineage pin for UI (patch) releases. A vM.m.p build with p>0 inherits vM.m.0's unyt.happ byte-for-byte, verified against happ_sha256 (see documentation/specs/release-patterns/release-pipeline.md + scripts/inherit-ui-release.sh). CI asserts `lineage` equals the tag's major.minor. happ_sha256 is the sha256 of the PUBLISHED v0.93.0 unyt.happ release asset (unytco/unyt-sandbox); update it when a new lineage's .0 is published.",
-  "lineage": "0.93",
-  "parent_tag": "v0.93.0",
-  "happ_sha256": "4eb446d5564e712bc55092d2fb8a954229e2957cd3b124508134d50dbc1e1d32"
+  "_comment": "Per-lineage pin for UI (patch) releases. A vM.m.p build with p>0 inherits vM.m.0's unyt.happ byte-for-byte, verified against happ_sha256 (see documentation/specs/release-patterns/release-pipeline.md + scripts/inherit-ui-release.sh). CI asserts `lineage` equals the tag's major.minor. happ_sha256 is the sha256 of the PUBLISHED v0.95.0 unyt.happ release asset (unytco/unyt-sandbox); update it when a new lineage's .0 is published.",
+  "lineage": "0.95",
+  "parent_tag": "v0.95.0",
+  "happ_sha256": "055c5ac3bbe26a120c60f694768e205ecc45988e469f3b8841ffdc56f7e53fb9"
 }

--- a/scripts/inherit-ui-release.sh
+++ b/scripts/inherit-ui-release.sh
@@ -37,32 +37,12 @@ got_sha="$(sha256sum "$tmp/unyt.happ" | awk '{print $1}')"
 [ "$got_sha" = "$expected_sha" ] ||
   fail "inherited unyt.happ sha256 $got_sha != committed lineage.json $expected_sha (mutated or wrong-tag release asset)"
 
-# 3. Source-diff guard — a change that would alter the BUILT DNA requires a NEW lineage (a vM.m+1.0
-#    migration release), not a UI patch. The DNA wasm compiles `crates/rave_engine` + `dnas/*/zomes/*`
-#    (`yarn build:zomes` = cargo build --workspace, excluding only unyt-sandbox / unyt_cli / sweettest),
-#    with every dep version pinned by the workspace manifest + lockfile — so DNA-affecting source lives
-#    OUTSIDE dnas/ too. Diff ALL of those inputs between the two pinned inner-app commits (NOT the
-#    submodule pointer, which changes on every UI release). Keep DNA_SOURCE in step with build:zomes if
-#    a new wasm-compiled crate is ever added under crates/. (smart_agreement_library is runtime
-#    agreement data, not compiled into the DNA, so it is deliberately not here.)
-parent_inner="$(git -C "$ROOT" ls-tree "$PARENT_TAG" unyt | awk '{print $3}')"
-current_inner="$(git -C "$ROOT/unyt" rev-parse HEAD)"
-[ -n "$parent_inner" ] || fail "could not read the unyt submodule pointer at $PARENT_TAG (is the outer checkout fetch-depth 0?)"
-git -C "$ROOT/unyt" cat-file -e "${parent_inner}^{commit}" 2>/dev/null ||
-  git -C "$ROOT/unyt" fetch --depth 1 origin "$parent_inner" 2>/dev/null ||
-  fail "cannot resolve the parent inner-app commit $parent_inner — fetch it (the inner submodule needs its history)"
-DNA_SOURCE=(dnas crates/rave_engine Cargo.toml Cargo.lock)
-if ! git -C "$ROOT/unyt" diff --quiet "$parent_inner" "$current_inner" -- "${DNA_SOURCE[@]}"; then
-  {
-    echo "DNA source changed between $PARENT_TAG and $TAG — a change under the DNA build inputs"
-    echo "(${DNA_SOURCE[*]}) requires a NEW LINEAGE (a vM.m+1.0 migration release), not a UI patch."
-    echo "Offending files:"
-    git -C "$ROOT/unyt" diff --stat "$parent_inner" "$current_inner" -- "${DNA_SOURCE[@]}"
-  } >&2
-  exit 1
-fi
+# No DNA-source-diff check: the digest guard above already pins the shipped unyt.happ to the parent
+# vM.m.0's exact bytes, so a UI release can never ship a different DNA. A UI patch may deliberately
+# ship a backward-compatible UI on the parent's DNA even after the DNA source has moved on toward the
+# next migration; which kind a tag is is the operator's call (vM.m.p = UI), not CI's to re-derive.
 
-# 4. Place the inherited artifacts + repack ONLY the UI. hc web-app pack consumes the inherited
+# 3. Place the inherited artifacts + repack ONLY the UI. hc web-app pack consumes the inherited
 #    ./unyt.happ (never repacks the DNA) and the freshly built ../ui/white-label/dist.zip.
 cp "$tmp/unyt.happ" "$ROOT/unyt/workdir/unyt.happ"
 [ -f "$tmp/alliance.dna" ] && cp "$tmp/alliance.dna" "$ROOT/unyt/dnas/alliance/workdir/alliance.dna"


### PR DESCRIPTION
`v0.95.1` is the first-ever UI-patch (`vM.m.p`) release — every prior tag (v0.90.0 … v0.95.0) was a `.0` migration release. Being the first patch, it's the first release to exercise the UI-inherit path, and it surfaced two problems that aborted the release run ([failed run](https://github.com/unytco/unyt-sandbox/actions/runs/30602626877)). This fixes both.

## 1. Advance the stale lineage pin (`lineage.json`)

`scripts/release-kind.sh` failed the build:

> lineage.json pins lineage '0.93', but tag v0.95.1 is on lineage '0.95' — update the pin before cutting a UI release on a new lineage

`lineage.json` still pinned the 0.93 lineage — it was never advanced when 0.94 and 0.95 shipped, because those were `.0` migration releases and the pin is only read for a UI release. v0.95.1 is the first patch, so it's the first tag to read it.

Advance it to the 0.95 lineage: `lineage: 0.95`, `parent_tag: v0.95.0`, and `happ_sha256` = the sha256 of the published `v0.95.0` `unyt.happ` release asset (`055c5ac3…`), which the digest guard verifies the inherited happ against.

## 2. Drop the source-diff guard (`scripts/inherit-ui-release.sh`)

With the pin fixed, the next step still aborted: the source-diff guard diffed the whole workspace `Cargo.toml`/`Cargo.lock` between the parent and this tag, and the mandatory version bump `0.95.0 → 0.95.1` touches them (the app crate `unyt-sandbox` must bump per the version contract; `transactor`/`transactor_integrity` inherit the workspace version). That flagged a **DNA-neutral** change as "DNA changed → cut a migration release" (verified: the diff is purely version strings; the app/CLI/test crates are excluded from the DNA build and `CARGO_PKG_VERSION` isn't compiled into the wasm).

The guard's premise is wrong for a UI release, so it's removed rather than patched:

- The **digest guard** (kept) already pins the shipped `unyt.happ`/DNA to the parent `.0`'s exact bytes — a UI release physically cannot ship a different DNA, whatever the app source contains.
- A UI patch may **intentionally** ship a backward-compatible UI on the parent's DNA even after the DNA source has moved on toward the next migration. Which kind a tag is is the operator's declaration (`vM.m.p` = UI), not something CI should re-derive from the source.

The digest and modifiers guards remain. The spec is updated to match in the umbrella (`documentation/specs/release-patterns/release-pipeline.md` + `README.md`).

## Result

`release-kind.sh v0.95.1` → `kind=ui` / `parent_tag=v0.95.0`; the inherit step verifies the digest and packs the UI onto the inherited `v0.95.0` DNA. Re-tagging `v0.95.1` on the merged tip re-runs the release green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UI patch releases can now proceed when DNA build inputs differ, while retaining validation of the published application digest.
  * Release validation continues to detect missing parent releases and required assets.

* **Chores**
  * Updated UI release lineage and the pinned application integrity hash for the 0.95 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->