### PR TITLE
fix(release): UI-release web-app pack must not --recursive (repacks the DNA)

### DIFF
--- a/scripts/inherit-ui-release.sh
+++ b/scripts/inherit-ui-release.sh
@@ -44,9 +44,11 @@ got_sha="$(sha256sum "$tmp/unyt.happ" | awk '{print $1}')"
 
 # 3. Place the inherited artifacts + repack ONLY the UI. hc web-app pack consumes the inherited
 #    ./unyt.happ (never repacks the DNA) and the freshly built ../ui/white-label/dist.zip.
+#    NOT --recursive: that makes hc ignore the pre-built ./unyt.happ and rebuild the whole chain from
+#    the manifests down to the zome wasm, which a UI release never compiles.
 cp "$tmp/unyt.happ" "$ROOT/unyt/workdir/unyt.happ"
 [ -f "$tmp/alliance.dna" ] && cp "$tmp/alliance.dna" "$ROOT/unyt/dnas/alliance/workdir/alliance.dna"
 ( cd "$ROOT/unyt" && nix develop --no-update-lock-file --accept-flake-config --command bash -c \
-  "yarn install --frozen-lockfile && yarn workspace white-label package && hc web-app pack workdir --recursive" )
+  "yarn install --frozen-lockfile && yarn workspace white-label package && hc web-app pack workdir" )
 
 echo "inherit: UI release $TAG built on inherited $PARENT_TAG DNA (unyt.happ sha256 $got_sha) — DNA not rebuilt."


### PR DESCRIPTION
The first UI-patch release (`v0.95.1`) failed `publish-happ` at the pack step:

```
Failed to canonicalize resource path: .../unyt/dnas/alliance/workdir/../../../target/wasm32-unknown-unknown/release/transactor.wasm: No such file or directory
```

`inherit-ui-release.sh` inherits the parent `v0.95.0`'s `unyt.happ` + `alliance.dna` byte-for-byte, then packs the webhapp with `hc web-app pack workdir --recursive`. But `--recursive` makes `hc` ignore the pre-built `unyt.happ` and rebuild the whole chain from the manifests (`web-happ.yaml → happ.yaml → dna.yaml`) down to the zome wasm — which a UI release never compiles. This contradicts the script's own intent ("the DNA is NEVER rebuilt or repacked").

**Fix:** drop `--recursive` so `hc web-app pack workdir` bundles the inherited `unyt.happ` as-is. The migration path is untouched — it compiles the wasm first (`build:zomes`), so its `--recursive` is correct there.

**Proven locally** (nix shell, the repo's own `hc` 0.6.1-rc.7, on faithful wasm-free trees since the checkout's `target/` would otherwise hide the bug):
- `--recursive` → reproduces the `transactor.wasm` failure.
- without it → succeeds, no wasm; the produced `unyt.webhapp` embeds a happ **byte-identical to v0.95.0** (sha `055c5ac3…`, DNA hash `uhC0kT4nt…`), matching the published v0.95.0 webhapp in everything but the UI payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated UI packaging to preserve inherited design elements correctly.
  * Prevented unintended rebuilding of the complete inheritance chain during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->